### PR TITLE
Fixing flakiness in ExplainPlanQueriesTest because of maps

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.HashUtil;
@@ -44,7 +45,7 @@ public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> {
 
   public ProjectionOperator(Map<String, DataSource> dataSourceMap,
       @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
-    _dataSourceMap = dataSourceMap;
+    _dataSourceMap = new TreeMap<>(dataSourceMap);
     _docIdSetOperator = docIdSetOperator;
     _dataBlockCache = new DataBlockCache(new DataFetcher(dataSourceMap));
     _columnContextMap = new HashMap<>(HashUtil.getHashMapCapacity(dataSourceMap.size()));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -152,9 +152,8 @@ public class QueriesTestUtils {
       ArrayList<Object> listOfObjects = new ArrayList<>();
       for (Object expectedObject : actual.get(i)) {
         if (expectedObject instanceof String) {
-          listOfObjects
-                  .add(Arrays.toString(Arrays.stream(((String) expectedObject)
-                          .replaceAll(" ", "").split("[(,)]")).sorted().toArray()));
+          listOfObjects.add(Arrays.toString(Arrays.stream(((String) expectedObject)
+                  .replaceAll(" ", "").split("[(,)]")).sorted().toArray()));
         } else {
           listOfObjects.add(expectedObject);
         }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -150,7 +150,7 @@ public class QueriesTestUtils {
     }
     for (int i = 0; i < expected.size(); i++) {
       ArrayList<Object> listOfObjects = new ArrayList<>();
-      for (Object expectedObject : actual.get(i)) {
+      for (Object expectedObject : expected.get(i)) {
         if (expectedObject instanceof String) {
           listOfObjects.add(Arrays.toString(Arrays.stream(((String) expectedObject)
                   .replaceAll(" ", "").split("[(,)]")).sorted().toArray()));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.queries;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
@@ -134,10 +134,10 @@ public class QueriesTestUtils {
 
   private static void validateRows(List<Object[]> actual, List<Object[]> expected) {
     assertEquals(actual.size(), expected.size());
-    HashMap<Integer, HashSet<Object>> actualHashmap = new HashMap<>();
-    HashMap<Integer, HashSet<Object>> expectedHashmap = new HashMap<>();
+    HashMap<Integer, ArrayList<Object>> actualHashmap = new HashMap<>();
+    HashMap<Integer, ArrayList<Object>> expectedHashmap = new HashMap<>();
     for (int i = 0; i < actual.size(); i++) {
-      HashSet<Object> listOfObjects = new HashSet<>();
+      ArrayList<Object> listOfObjects = new ArrayList<>();
       for (Object actualObject : actual.get(i)) {
         if (actualObject instanceof String) {
           listOfObjects.add(Arrays.toString(Arrays.stream(((String) actualObject)
@@ -149,7 +149,7 @@ public class QueriesTestUtils {
       actualHashmap.put(i, listOfObjects);
     }
     for (int i = 0; i < expected.size(); i++) {
-      HashSet<Object> listOfObjects = new HashSet<>();
+      ArrayList<Object> listOfObjects = new ArrayList<>();
       for (Object expectedObject : actual.get(i)) {
         if (expectedObject instanceof String) {
           listOfObjects

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -21,7 +21,7 @@ package org.apache.pinot.queries;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
@@ -134,8 +134,8 @@ public class QueriesTestUtils {
 
   private static void validateRows(List<Object[]> actual, List<Object[]> expected) {
     assertEquals(actual.size(), expected.size());
-    HashMap<Integer, ArrayList<Object>> actualHashmap = new HashMap<>();
-    HashMap<Integer, ArrayList<Object>> expectedHashmap = new HashMap<>();
+    HashSet<ArrayList<Object>> actualHashSet = new HashSet<>();
+    HashSet<ArrayList<Object>> expectedHashSet = new HashSet<>();
     for (int i = 0; i < actual.size(); i++) {
       ArrayList<Object> listOfObjects = new ArrayList<>();
       for (Object actualObject : actual.get(i)) {
@@ -146,7 +146,7 @@ public class QueriesTestUtils {
           listOfObjects.add(actualObject);
         }
       }
-      actualHashmap.put(i, listOfObjects);
+      actualHashSet.add(listOfObjects);
     }
     for (int i = 0; i < expected.size(); i++) {
       ArrayList<Object> listOfObjects = new ArrayList<>();
@@ -159,9 +159,9 @@ public class QueriesTestUtils {
           listOfObjects.add(expectedObject);
         }
       }
-      expectedHashmap.put(i, listOfObjects);
+      expectedHashSet.add(listOfObjects);
     }
-    assertEquals(actualHashmap, expectedHashmap);
+    assertEquals(actualHashSet, expectedHashSet);
   }
 
   public static void testInterSegmentsResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -20,6 +20,8 @@ package org.apache.pinot.queries;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Function;
@@ -132,10 +134,34 @@ public class QueriesTestUtils {
 
   private static void validateRows(List<Object[]> actual, List<Object[]> expected) {
     assertEquals(actual.size(), expected.size());
+    HashMap<Integer, HashSet<Object>> actualHashmap = new HashMap<>();
+    HashMap<Integer, HashSet<Object>> expectedHashmap = new HashMap<>();
     for (int i = 0; i < actual.size(); i++) {
-      // Generic assertEquals delegates to assertArrayEquals, which can test for equality of array values in rows.
-      assertEquals((Object) actual.get(i), (Object) expected.get(i));
+      HashSet<Object> listOfObjects = new HashSet<>();
+      for (Object actualObject : actual.get(i)) {
+        if (actualObject instanceof String) {
+          listOfObjects.add(Arrays.toString(Arrays.stream(((String) actualObject)
+                  .replaceAll(" ", "").split("[(,)]")).sorted().toArray()));
+        } else {
+          listOfObjects.add(actualObject);
+        }
+      }
+      actualHashmap.put(i, listOfObjects);
     }
+    for (int i = 0; i < expected.size(); i++) {
+      HashSet<Object> listOfObjects = new HashSet<>();
+      for (Object expectedObject : actual.get(i)) {
+        if (expectedObject instanceof String) {
+          listOfObjects
+                  .add(Arrays.toString(Arrays.stream(((String) expectedObject)
+                          .replaceAll(" ", "").split("[(,)]")).sorted().toArray()));
+        } else {
+          listOfObjects.add(expectedObject);
+        }
+      }
+      expectedHashmap.put(i, listOfObjects);
+    }
+    assertEquals(actualHashmap, expectedHashmap);
   }
 
   public static void testInterSegmentsResult(BrokerResponseNative brokerResponse, long expectedNumDocsScanned,

--- a/pom.xml
+++ b/pom.xml
@@ -1468,7 +1468,8 @@
         -->
         <configuration>
           <testFailureIgnore>false</testFailureIgnore>
-          <argLine>-Dlog4j.configuration=</argLine> // This change is made to run the project locally, it will not be a part of the actual PR
+          <argLine>-Dlog4j.configuration=</argLine>
+          <!-- Excludes integration tests when unit tests are run. -->
           <excludes>
             <exclude>**/*IT.java</exclude>
           </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -1330,6 +1330,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
           <configuration>
+            <argLine>-Dlog4j.configuration=</argLine> // This change is made to run the project locally, it will not be a part of the actual PR
             <forkCount>1</forkCount>
             <reuseForks>false</reuseForks>
             <!-- 60 minutes -->

--- a/pom.xml
+++ b/pom.xml
@@ -1330,7 +1330,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
           <configuration>
-            <argLine>-Dlog4j.configuration=</argLine> // This change is made to run the project locally, it will not be a part of the actual PR
             <forkCount>1</forkCount>
             <reuseForks>false</reuseForks>
             <!-- 60 minutes -->
@@ -1469,7 +1468,7 @@
         -->
         <configuration>
           <testFailureIgnore>false</testFailureIgnore>
-          <!-- Excludes integration tests when unit tests are run. -->
+          <argLine>-Dlog4j.configuration=</argLine> // This change is made to run the project locally, it will not be a part of the actual PR
           <excludes>
             <exclude>**/*IT.java</exclude>
           </excludes>


### PR DESCRIPTION
### **The purpose this PR is to fix flakiness in the test:** 

`org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperators`

### Steps to run the test

- Clone the repository `https://github.com/VidhiRambhia/pinot`
- Checkout the branch `flaky-test-fix`
- Run maven install for `pinot-core` (which has the test file) in the repository:
`mvn install -pl pinot-core -DskipTests`
- Run the test:
`mvn -pl pinot-core test -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperator`s
- Run the test with NonDex: 
`mvn -pl pinot-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperators`

Note: The changes in pom.xml have been added to make nondex run on the tests in this file locally. These changes will not be a part of the final PR.
```
<argLine>-Dlog4j.configuration=</argLine>
```

### Analysis
The test is written to verify the output of the EXPLAIN PLAN SQL query. Reference - https://docs.oracle.com/cd/E28271_01/server.1111/e16638/ex_plan.htm

The underlying code in the test makes use of hashmaps in several places. However, there is one point in execution of code where a changed ordering would break the test. This point is when we fetch unique explain plan row data getAllSegmentsUniqueExplainPlanRowData(root);. This function works by identifying similar rows through a comparison of hashcodes. Two strings with essentially the same value and different ordering like: "noIndexCol1, invertedIndexCol3, invertedIndexCol1" and "noIndexCol1, invertedIndexCol1, invertedIndexCol3" will have different hashcodes and hence will be treated as different plan rows. To solve this, digging deeper, I found that the string is generated at org.apache.pinot.core.operator.ProjectionOperator#toExplainString. This function iterates over a _dataSourceMap the outputs of which can be randomly shuffled.

### Rationale of the fix
The solution is to use a **TreeMap** (https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/TreeMap.html) which sorts the keys internally. This ensures that we end up with the same order with every run. However, the expected values may not use a sorted ordering of column values. This test and all other tests that go through the same code will either need changes in assertion (in over 20 places). Additionally, future developers also need to be mindful of this order while adding unit tests in this module. To avoid this overhead, the employed fix does not change assertions in the main test file. Instead it asserts on the returned values in such a way that the order of values returned in the string part of the query doesn't matter.

Using a hashset to compare the actual and expected objects with splitting and sorting strings appropriately solves this problem. Note that we do not use a single for loop to populate actual and expected hashsets. If the actual and expected rows values do not follow a particular order, the comparison will be flaky.

### Verifying the fix:

- [ ] **Does the test pass when it is runs without any shuffling of data structures?**

Yes. The following command was used for for testing this -

`mvn -pl pinot-core test -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperators`

- [ ] **Does the test pass when it is run with NonDex?**

Yes. The fix has been run with -DnondexRuns set to 3 (default), 10 and 100. All of them passed. The following commands were used for testing this:

```
mvn -pl pinot-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperators -DnondexRuns = 3
mvn -pl pinot-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperators -DnondexRuns = 10
mvn -pl pinot-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest#testSelectColumnsVariationsOfAndOperators -DnondexRuns = 100
```

- [ ] **Does the test break other tests in its file?**

No. The fix doesn't break any other test in its file. Infact, it corrects other flaky tests in the file. The following command was used for testing this:

`mvn -pl pinot-core test -Dtest=org.apache.pinot.queries.ExplainPlanQueriesTest`

- [ ] Does the test break other tests in its module?

No. The fix doesn't break any other test in its module. The following command was used for testing this:

`mvn -pl pinot-core test`

