### PR TITLE
Fixing a flaky test in JsonIngestionFromAvroQueriesTest

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
@@ -186,8 +186,8 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
             createEnumField(enumSchema, "LEFT"), createFixedField(fixedSchema, 4), new byte[] {0, 0, 0, 4}));
 
     // insert RECORD
-    inputRecords.add(createTableRecord(5, "minney mouse", createRecordField("id", 1, "name", "minney"),
-        createEnumField(enumSchema, "RIGHT"), createFixedField(fixedSchema, 5), new byte[] {0, 0, 0, 5}));
+    inputRecords.add(createTableRecord(5, "minney mouse", "{\"id\":1,\"name\":\"minney\"}",
+            createEnumField(enumSchema, "RIGHT"), createFixedField(fixedSchema, 5), new byte[] {0, 0, 0, 5}));
 
     // Insert simple Java String (gets converted into JSON value)
     inputRecords.add(


### PR DESCRIPTION
### The purpose this PR is to fix flakiness in the test:

**org.apache.pinot.queries.JsonIngestionFromAvroQueriesTest.JsonPathSelectOnJsonColumn**

### Cause of Flakiness

After debugging I found out that the problem with failing assertions is not the order of outputs.
The way the output is deserialized from Avro files is erroneous.
The code to deserialize and index data is in a different module than pinot-core. That is why, it is not possible to fix the flaky test with code changes in just pinot-core.

As a temporary fix, we can change the way data is ingested for the entry 

```agsl
    inputRecords.add(createTableRecord(5, "minney mouse", createRecordField("id", 1, "name", "minney"),
        createEnumField(enumSchema, "RIGHT"), createFixedField(fixedSchema, 5), new byte[] {0, 0, 0, 5}));
```

This record specifically isn't deserialized properly with the current code. 
Instead of ```createRecordField("id", 1, "name", "minney")```, we can pass a JSON string ```{"id":"1", "name":"minney"}```
This fix deserializes data properly and removes flakiness of the test

### Debugging and Analysis

1. The input record where data is inserted with a GenericRecord.Data is the root cause of flakiness.
2. There are no issues with writing this data in the Avro file.
3. At the time of reading, a GenericRow decoder is initialized.
4. Till this point, the output is deserialized as expected.
5. In the next step, an index creator is invoked.
6. This index creator writes the values of all columns in the data to a dictionary.
7. Finally this function is invoked:

```agsl
  private void indexSingleValueRow(SegmentDictionaryCreator dictionaryCreator, Object value,
      Map<IndexType<?, ?, ?>, IndexCreator> creatorsByIndex)
      throws IOException {
    int dictId = dictionaryCreator != null ? dictionaryCreator.indexOfSV(value) : -1;
    for (IndexCreator creator : creatorsByIndex.values()) {
      creator.add(value, dictId);
    }
  }
```
8. The problem lies with the map creatorsByIndex.
9. It does not guarantee the order in which we insert values in creator.
10. When tests are run, values are read from this dictionary, which is erroneously populated.
